### PR TITLE
Fix initial errors on dev server startup

### DIFF
--- a/src/components/SalaryPaymentForm.tsx
+++ b/src/components/SalaryPaymentForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import Swal from '../pages/swal';
+import Swal from 'sweetalert2';
 import { 
   DollarSign, 
   Calendar, 

--- a/src/components/WarningLetterGenerator.tsx
+++ b/src/components/WarningLetterGenerator.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import Swal from '../pages/swal';
+import Swal from 'sweetalert2';
 import { FileText, Download, Send, X, AlertTriangle, Save, Printer, Mail } from 'lucide-react';
 import { supabase } from '../utils/supabaseClient';
 import { jsPDF } from 'jspdf';

--- a/src/pages/AdminDashboardPage.tsx
+++ b/src/pages/AdminDashboardPage.tsx
@@ -38,13 +38,13 @@ import {
 import WarningLetterGenerator from '../components/WarningLetterGenerator';
 import NotificationSystem from '../components/NotificationSystem';
 import StatCard from '../components/ui/StatCard';
-import { User, Profile } from '../types';
+import { User as UserType, Profile } from '../types';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend);
 
 const AdminDashboardPage = () => {
   const navigate = useNavigate();
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<UserType | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
   const [isCollapsed, setIsCollapsed] = useState(false);

--- a/src/pages/AttendanceHistory.tsx
+++ b/src/pages/AttendanceHistory.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Calendar, Filter, Download, CheckCircle, XCircle, AlertTriangle, Users, Search, RefreshCw, MapPin } from 'lucide-react';
 import { supabase } from '../utils/supabaseClient';
-import Swal from './swal';
+import Swal from 'sweetalert2';
 
 const AttendanceHistory = () => {
   const navigate = useNavigate();

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -14,7 +14,7 @@ import NotificationSystem from '../components/NotificationSystem';
 import AttendanceHistory from './AttendanceHistory';
 import ProfileEditor from '../features/karyawan/profile/ProfileEditor';
 import StatCard from '../components/ui/StatCard';
-import { User, Profile } from '../types';
+import { User as UserType, Profile } from '../types';
 
 // Calendar component (simplified version)
 const ReactCalendar = ({ onChange, value, tileContent, tileClassName, locale, className, prevLabel, nextLabel, navigationLabel }: {
@@ -111,7 +111,7 @@ const ReactCalendar = ({ onChange, value, tileContent, tileClassName, locale, cl
 
 const DashboardPage = () => {
   const navigate = useNavigate();
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<UserType | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [todayAttendance, setTodayAttendance] = useState<any[]>([]);
   const [salaryInfo, setSalaryInfo] = useState<any | null>(null);

--- a/src/pages/PositionManagement.tsx
+++ b/src/pages/PositionManagement.tsx
@@ -15,7 +15,7 @@ import {
   XCircle,
   Briefcase
 } from 'lucide-react';
-import Swal from './swal';
+import Swal from 'sweetalert2';
 import { supabase } from '../utils/supabaseClient';
 import AdminSidebar from '../components/AdminSidebar';
 

--- a/src/pages/UserManagement.tsx
+++ b/src/pages/UserManagement.tsx
@@ -20,7 +20,7 @@ import {
   XCircle
 } from 'lucide-react';
 import { supabase, uploadFile, getFileUrl } from '../utils/supabaseClient';
-import Swal from './swal';
+import Swal from 'sweetalert2';
 import ProfileModal from '../components/ProfileModal';
 import CustomFaceCapture from '../components/CustomFaceCapture';
 import AdminSidebar from '../components/AdminSidebar';


### PR DESCRIPTION
This commit fixes several errors that were preventing the dev server from starting up correctly:

- Renames the `User` type import from `../types` to `UserType` to avoid a name collision with the `User` icon from `lucide-react`.
- Corrects all incorrect `swal` imports to point to `sweetalert2` instead of a non-existent local file.